### PR TITLE
change the search colors in alacritty according to neovims theme

### DIFF
--- a/extras/alacritty/nvim-dark.toml
+++ b/extras/alacritty/nvim-dark.toml
@@ -14,11 +14,11 @@ cursor = "#E0E2EA"
 
 [colors.search.matches]
 foreground = "#14161b"
-background = "#4f5258"
+background = "#6b5300"
 
 [colors.search.focused_match]
 foreground = "#14161b"
-background = "#7EDFDE"
+background = "#fce094"
 
 [colors.footer_bar]
 foreground = "#14161b"


### PR DESCRIPTION
the search colors used in alacrittys theme are some blue and grey changed them to nvimlightyellow and nvimdarkyellow
<img width="802" height="632" alt="Screenshot 2025-11-10 190834" src="https://github.com/user-attachments/assets/26ffa8bb-e709-4081-9fca-84d901cf5b01" />
----
<img width="802" height="632" alt="Screenshot 2025-11-10 191248" src="https://github.com/user-attachments/assets/6104ebcd-cf51-4c62-b637-496e1220c3fd" />
